### PR TITLE
Fix browser-support related bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14731,8 +14731,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -17079,7 +17078,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
       "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -17195,10 +17193,9 @@
       }
     },
     "react-app-polyfill": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.1.3.tgz",
-      "integrity": "sha512-Fl5Pic4F15G05qX7RmUqPZr1MtyFKJKSlRwMhel4kvDLrk/KcQ9QbpvyMTzv/0NN5957XFQ7r1BNHWi7qN59Pw==",
-      "dev": true,
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.0.tgz",
+      "integrity": "sha512-uBfocjRsBNqhTaEywUZ2buzhHbor2jBbnhZY8VUZ7VZ3PXucIPZrPDAAmbclELhvl+x08PbynAGQfMYcBmqZ2w==",
       "requires": {
         "core-js": "2.5.7",
         "object-assign": "4.1.1",
@@ -17210,14 +17207,12 @@
         "core-js": {
           "version": "2.5.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-          "dev": true
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
         },
         "promise": {
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
           "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
-          "dev": true,
           "requires": {
             "asap": "~2.0.6"
           }
@@ -17478,6 +17473,34 @@
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
+          }
+        },
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "dev": true
+        },
+        "promise": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
+          "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+          "dev": true,
+          "requires": {
+            "asap": "~2.0.6"
+          }
+        },
+        "react-app-polyfill": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.1.3.tgz",
+          "integrity": "sha512-Fl5Pic4F15G05qX7RmUqPZr1MtyFKJKSlRwMhel4kvDLrk/KcQ9QbpvyMTzv/0NN5957XFQ7r1BNHWi7qN59Pw==",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.7",
+            "object-assign": "4.1.1",
+            "promise": "8.0.2",
+            "raf": "3.4.0",
+            "whatwg-fetch": "3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "source": "src/DevTools.js",
   "scripts": {
     "prestart": "prestart",
-    "build": "zero build",
+    "build": "BUILD_WEBPACK=true zero build",
     "build:single": "node scripts/build-single.js",
     "build:umd": "node scripts/build-umd.js",
     "bundle": "npm run build:single && npm run build:umd",
@@ -48,6 +48,7 @@
   "dependencies": {
     "@helpscout/hsds-react": "^2.5.0",
     "@helpscout/wedux": "^0.0.11",
+    "react-app-polyfill": "^0.2.0",
     "react-color": "2.14.1",
     "react-rnd": "9.0.4"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import 'react-app-polyfill/ie11'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import DevTools from './DevTools'


### PR DESCRIPTION
@ItsJonQ  I think I've narrowed down the problem to two different issues - both of which occur in their own way on IE11. 

## Problem 1

When running the project locally the following errors are being thrown in the console 
<img width="586" alt="screen shot 2019-01-12 at 11 50 44 pm" src="https://user-images.githubusercontent.com/7111256/51083529-9cbab080-16d0-11e9-8f04-fb863c292731.png">


### Background

Create React App(CRA) does not allow for overriding config files like `babel.rc`. So if the user runs `npm run start` which calls `react-scripts start`, CRA doesn't read the local Babel file and the `@helpscout/zero/babel` preset is not being consumed. 

### How to reproduce
- Start up local dev server `npm run start`
- Navigate to BrowserStack and load IE11
- Open the console then navigate to the dev servers url
- Note the error shown in the console. If you navigate to the line in the code that is error via the console you'll notice that the output code is ES6 object property value shorthand instead of ES5 code and that `Promise is undefined` errors are also being thrown

### How to fix

- Install `'react-app-polyfill/ie11’` and require at the top of  `index.js` file
- (Another possible, but undesirable fix, for this would be to eject from CRA and maintain configurations ourselves then local config files could 
 be updated. But this seems to be what the `kcd-scripts` dependency (mentioned below) is helping to alleviate the need for. So the first suggested fix seems like the best option. )


## Problem 2

When running a build of Beacon DevTools the built files are not being compiled correctly for required browsers - i.e. IE11.

### Background

One of the Beacon DevTools' dependencies, `Zero`,  inherited a requirement (or quirk 😉) from its inspiration `kcd-scripts` (also a dependency of `Zero`). Inside of `zero/src/config/babelrc.js` this line https://github.com/helpscout/zero/blob/master/src/config/babelrc.js#L38 is loading the declared browserslist  from Beacon DevTools' `package.json`: 

```
"browserslist": [
    ">0.2%",
    "not dead",
    "not ie <= 11",
    "not op_mini all"
  ],

```

The problem (quirk) is occurring on this line: https://github.com/helpscout/zero/blob/master/src/config/babelrc.js#L43. For the `browsersConfig` to be consumed it is required that one of two environment variables are set at runtime: Either `BUILD_WEBPACK` or `BUILD_ROLLUP`. Because this is not currently occurring, the build target is `node` which is not compiling correctly to support required browsers.

### How to reproduce

How to reproduction:
- run `npm run build`
- Look in `dist/actions/index.js`
- Note that (approx) line 19 is not being compiled from the ES6 object property shorthand to the ES5 version (If I remember correctly this is the line that is breaking in Beacon 2.1 when running the app in IE11)

### How to fix

- Update the build task to `BUILD_WEBPACK=true zero build`
